### PR TITLE
fix: relaxes favicon link test

### DIFF
--- a/.autograding/__tests__/test1.js
+++ b/.autograding/__tests__/test1.js
@@ -36,7 +36,7 @@ describe('index.html', () => {
   });
 
   test('contains exactly one <link /> element pointing to a favicon', () => {
-    expect(html.querySelectorAll('head link[rel=icon]').length).toBe(1);
+    expect(html.querySelectorAll('head link[rel*=icon]').length).toBe(1);
   });
 
   test('contains exactly one <h1 /> element', () => {


### PR DESCRIPTION
Now passes for other valid attribute values, e.g. "shortcut icon"